### PR TITLE
fix: refresh cached AWS credentials before expiration

### DIFF
--- a/advanced/moving-legacy-scripts-to-functions/samsarafnsecrets.py
+++ b/advanced/moving-legacy-scripts-to-functions/samsarafnsecrets.py
@@ -1,15 +1,37 @@
-import os
-import boto3
+import datetime
 import json
+import os
 from typing import Callable
 
+import boto3
 
 _credentials: None | dict[str, str] = None
+_credentials_expiration: datetime.datetime | None = None
+_CREDENTIAL_REFRESH_MARGIN = datetime.timedelta(minutes=20)
 
 
-def get_credentials(force_refresh=False) -> dict[str, str]:
-    global _credentials
-    if _credentials is not None and not force_refresh:
+def _normalize_expiration(
+    value: str | datetime.datetime,
+) -> datetime.datetime:
+    """Return an expiration timestamp as a timezone-aware UTC datetime."""
+    if isinstance(value, str):
+        value = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=datetime.timezone.utc)
+    return value.astimezone(datetime.timezone.utc)
+
+
+def get_credentials(force_refresh: bool = False) -> dict[str, str]:
+    global _credentials, _credentials_expiration
+    refresh_deadline = (
+        datetime.datetime.now(datetime.timezone.utc) + _CREDENTIAL_REFRESH_MARGIN
+    )
+    cache_is_valid = (
+        _credentials is not None
+        and _credentials_expiration is not None
+        and refresh_deadline < _credentials_expiration
+    )
+    if cache_is_valid and not force_refresh:
         return _credentials
 
     sts = boto3.client("sts")
@@ -17,11 +39,13 @@ def get_credentials(force_refresh=False) -> dict[str, str]:
         RoleArn=os.environ["SamsaraFunctionExecRoleArn"],
         RoleSessionName=os.environ["SamsaraFunctionName"],
     )
+    credentials = res["Credentials"]
     _credentials = {
-        "aws_access_key_id": res["Credentials"]["AccessKeyId"],
-        "aws_secret_access_key": res["Credentials"]["SecretAccessKey"],
-        "aws_session_token": res["Credentials"]["SessionToken"],
+        "aws_access_key_id": credentials["AccessKeyId"],
+        "aws_secret_access_key": credentials["SecretAccessKey"],
+        "aws_session_token": credentials["SessionToken"],
     }
+    _credentials_expiration = _normalize_expiration(credentials["Expiration"])
     return _credentials
 
 

--- a/advanced/painting-preview/steps/samsarafnsecrets.py
+++ b/advanced/painting-preview/steps/samsarafnsecrets.py
@@ -1,14 +1,36 @@
-import os
-import boto3
+import datetime
 import json
+import os
 
+import boto3
 
 _credentials: None | dict[str, str] = None
+_credentials_expiration: datetime.datetime | None = None
+_CREDENTIAL_REFRESH_MARGIN = datetime.timedelta(minutes=20)
 
 
-def get_credentials(force_refresh=False) -> dict[str, str]:
-    global _credentials
-    if _credentials is not None and not force_refresh:
+def _normalize_expiration(
+    value: str | datetime.datetime,
+) -> datetime.datetime:
+    """Return an expiration timestamp as a timezone-aware UTC datetime."""
+    if isinstance(value, str):
+        value = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=datetime.timezone.utc)
+    return value.astimezone(datetime.timezone.utc)
+
+
+def get_credentials(force_refresh: bool = False) -> dict[str, str]:
+    global _credentials, _credentials_expiration
+    refresh_deadline = (
+        datetime.datetime.now(datetime.timezone.utc) + _CREDENTIAL_REFRESH_MARGIN
+    )
+    cache_is_valid = (
+        _credentials is not None
+        and _credentials_expiration is not None
+        and refresh_deadline < _credentials_expiration
+    )
+    if cache_is_valid and not force_refresh:
         return _credentials
 
     sts = boto3.client("sts")
@@ -16,11 +38,13 @@ def get_credentials(force_refresh=False) -> dict[str, str]:
         RoleArn=os.environ["SamsaraFunctionExecRoleArn"],
         RoleSessionName=os.environ["SamsaraFunctionName"],
     )
+    credentials = res["Credentials"]
     _credentials = {
-        "aws_access_key_id": res["Credentials"]["AccessKeyId"],
-        "aws_secret_access_key": res["Credentials"]["SecretAccessKey"],
-        "aws_session_token": res["Credentials"]["SessionToken"],
+        "aws_access_key_id": credentials["AccessKeyId"],
+        "aws_secret_access_key": credentials["SecretAccessKey"],
+        "aws_session_token": credentials["SessionToken"],
     }
+    _credentials_expiration = _normalize_expiration(credentials["Expiration"])
     return _credentials
 
 

--- a/advanced/painting-preview/steps/samsarafnstorage.py
+++ b/advanced/painting-preview/steps/samsarafnstorage.py
@@ -1,6 +1,8 @@
 import base64
+import datetime
 import json
 import os
+
 import boto3
 
 
@@ -10,12 +12,21 @@ class Storage:
     Can be used to store files, images, etc.
     """
 
-    def __init__(self, credentials: dict[str, str]):
+    def __init__(self):
+        credentials = get_credentials()
+        self._credentials = credentials
         self.client = boto3.client("s3", **credentials)
         self.bucket = os.environ["SamsaraFunctionStorageName"]
 
+    def _get_client(self):
+        credentials = get_credentials()
+        if credentials != self._credentials:
+            self._credentials = credentials
+            self.client = boto3.client("s3", **credentials)
+        return self.client
+
     def put(self, Key: str, Body: bytes, **kwargs):
-        return self.client.put_object(
+        return self._get_client().put_object(
             Bucket=self.bucket,
             Key=Key,
             Body=Body,
@@ -26,7 +37,7 @@ class Storage:
         return self.put(Key, Body=base64.b64decode(Base64), **kwargs)
 
     def get(self, Key: str, **kwargs):
-        return self.client.get_object(
+        return self._get_client().get_object(
             Bucket=self.bucket,
             Key=Key,
             **kwargs,
@@ -40,7 +51,7 @@ class Storage:
         return base64.b64encode(body).decode("utf-8")
 
     def delete(self, Key: str, **kwargs):
-        return self.client.delete_object(
+        return self._get_client().delete_object(
             Bucket=self.bucket,
             Key=Key,
             **kwargs,
@@ -51,7 +62,7 @@ class Storage:
         Prefix: str = "",
         **kwargs,
     ):
-        return self.client.list_objects_v2(
+        return self._get_client().list_objects_v2(
             Bucket=self.bucket,
             Prefix=Prefix,
             **kwargs,
@@ -83,11 +94,32 @@ class Storage:
 
 
 _credentials: None | dict[str, str] = None
+_credentials_expiration: datetime.datetime | None = None
+_CREDENTIAL_REFRESH_MARGIN = datetime.timedelta(minutes=20)
 
 
-def get_credentials(force_refresh=False) -> dict[str, str]:
-    global _credentials
-    if _credentials is not None and not force_refresh:
+def _normalize_expiration(
+    value: str | datetime.datetime,
+) -> datetime.datetime:
+    """Return an expiration timestamp as a timezone-aware UTC datetime."""
+    if isinstance(value, str):
+        value = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=datetime.timezone.utc)
+    return value.astimezone(datetime.timezone.utc)
+
+
+def get_credentials(force_refresh: bool = False) -> dict[str, str]:
+    global _credentials, _credentials_expiration
+    refresh_deadline = (
+        datetime.datetime.now(datetime.timezone.utc) + _CREDENTIAL_REFRESH_MARGIN
+    )
+    cache_is_valid = (
+        _credentials is not None
+        and _credentials_expiration is not None
+        and refresh_deadline < _credentials_expiration
+    )
+    if cache_is_valid and not force_refresh:
         return _credentials
 
     sts = boto3.client("sts")
@@ -95,11 +127,13 @@ def get_credentials(force_refresh=False) -> dict[str, str]:
         RoleArn=os.environ["SamsaraFunctionExecRoleArn"],
         RoleSessionName=os.environ["SamsaraFunctionName"],
     )
+    credentials = res["Credentials"]
     _credentials = {
-        "aws_access_key_id": res["Credentials"]["AccessKeyId"],
-        "aws_secret_access_key": res["Credentials"]["SecretAccessKey"],
-        "aws_session_token": res["Credentials"]["SessionToken"],
+        "aws_access_key_id": credentials["AccessKeyId"],
+        "aws_secret_access_key": credentials["SecretAccessKey"],
+        "aws_session_token": credentials["SessionToken"],
     }
+    _credentials_expiration = _normalize_expiration(credentials["Expiration"])
     return _credentials
 
 
@@ -111,7 +145,7 @@ def get_storage() -> Storage:
     if _storage is not None:
         return _storage
 
-    _storage = Storage(get_credentials())
+    _storage = Storage()
     return _storage
 
 

--- a/advanced/ppe-detection/samsarafnsecrets.py
+++ b/advanced/ppe-detection/samsarafnsecrets.py
@@ -1,14 +1,36 @@
-import os
-import boto3
+import datetime
 import json
+import os
 
+import boto3
 
 _credentials: None | dict[str, str] = None
+_credentials_expiration: datetime.datetime | None = None
+_CREDENTIAL_REFRESH_MARGIN = datetime.timedelta(minutes=20)
 
 
-def get_credentials(force_refresh=False) -> dict[str, str]:
-    global _credentials
-    if _credentials is not None and not force_refresh:
+def _normalize_expiration(
+    value: str | datetime.datetime,
+) -> datetime.datetime:
+    """Return an expiration timestamp as a timezone-aware UTC datetime."""
+    if isinstance(value, str):
+        value = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=datetime.timezone.utc)
+    return value.astimezone(datetime.timezone.utc)
+
+
+def get_credentials(force_refresh: bool = False) -> dict[str, str]:
+    global _credentials, _credentials_expiration
+    refresh_deadline = (
+        datetime.datetime.now(datetime.timezone.utc) + _CREDENTIAL_REFRESH_MARGIN
+    )
+    cache_is_valid = (
+        _credentials is not None
+        and _credentials_expiration is not None
+        and refresh_deadline < _credentials_expiration
+    )
+    if cache_is_valid and not force_refresh:
         return _credentials
 
     sts = boto3.client("sts")
@@ -16,11 +38,13 @@ def get_credentials(force_refresh=False) -> dict[str, str]:
         RoleArn=os.environ["SamsaraFunctionExecRoleArn"],
         RoleSessionName=os.environ["SamsaraFunctionName"],
     )
+    credentials = res["Credentials"]
     _credentials = {
-        "aws_access_key_id": res["Credentials"]["AccessKeyId"],
-        "aws_secret_access_key": res["Credentials"]["SecretAccessKey"],
-        "aws_session_token": res["Credentials"]["SessionToken"],
+        "aws_access_key_id": credentials["AccessKeyId"],
+        "aws_secret_access_key": credentials["SecretAccessKey"],
+        "aws_session_token": credentials["SessionToken"],
     }
+    _credentials_expiration = _normalize_expiration(credentials["Expiration"])
     return _credentials
 
 

--- a/advanced/ppe-detection/samsarafnstorage.py
+++ b/advanced/ppe-detection/samsarafnstorage.py
@@ -1,6 +1,8 @@
 import base64
+import datetime
 import json
 import os
+
 import boto3
 import botocore.exceptions
 
@@ -11,9 +13,18 @@ class Storage:
     Can be used to store files, images, etc.
     """
 
-    def __init__(self, credentials: dict[str, str]):
+    def __init__(self):
+        credentials = get_credentials()
+        self._credentials = credentials
         self.client = boto3.client("s3", **credentials)
         self.bucket = os.environ["SamsaraFunctionStorageName"]
+
+    def _get_client(self):
+        credentials = get_credentials()
+        if credentials != self._credentials:
+            self._credentials = credentials
+            self.client = boto3.client("s3", **credentials)
+        return self.client
 
     def put(self, Key: str, Body: bytes, **kwargs):
         """
@@ -21,7 +32,7 @@ class Storage:
         Kwargs are passed to the underlying boto3.client('s3').put_object().
         Returns the original boto3 response.
         """
-        return self.client.put_object(
+        return self._get_client().put_object(
             Bucket=self.bucket,
             Key=Key,
             Body=Body,
@@ -43,7 +54,7 @@ class Storage:
         Kwargs are passed to the underlying `boto3.client('s3').get_object()`.
         Returns the original boto3 response.
         """
-        return self.client.get_object(
+        return self._get_client().get_object(
             Bucket=self.bucket,
             Key=Key,
             **kwargs,
@@ -72,7 +83,7 @@ class Storage:
         Kwargs are passed to the underlying `boto3.client('s3').delete_object()`.
         Returns the original boto3 response.
         """
-        return self.client.delete_object(
+        return self._get_client().delete_object(
             Bucket=self.bucket,
             Key=Key,
             **kwargs,
@@ -88,7 +99,7 @@ class Storage:
         Kwargs are passed to the underlying `boto3.client('s3').list_objects_v2()`.
         Returns the original boto3 response.
         """
-        return self.client.list_objects_v2(
+        return self._get_client().list_objects_v2(
             Bucket=self.bucket,
             Prefix=Prefix,
             **kwargs,
@@ -182,11 +193,32 @@ class Database:
 
 
 _credentials: None | dict[str, str] = None
+_credentials_expiration: datetime.datetime | None = None
+_CREDENTIAL_REFRESH_MARGIN = datetime.timedelta(minutes=20)
 
 
-def get_credentials(force_refresh=False) -> dict[str, str]:
-    global _credentials
-    if _credentials is not None and not force_refresh:
+def _normalize_expiration(
+    value: str | datetime.datetime,
+) -> datetime.datetime:
+    """Return an expiration timestamp as a timezone-aware UTC datetime."""
+    if isinstance(value, str):
+        value = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=datetime.timezone.utc)
+    return value.astimezone(datetime.timezone.utc)
+
+
+def get_credentials(force_refresh: bool = False) -> dict[str, str]:
+    global _credentials, _credentials_expiration
+    refresh_deadline = (
+        datetime.datetime.now(datetime.timezone.utc) + _CREDENTIAL_REFRESH_MARGIN
+    )
+    cache_is_valid = (
+        _credentials is not None
+        and _credentials_expiration is not None
+        and refresh_deadline < _credentials_expiration
+    )
+    if cache_is_valid and not force_refresh:
         return _credentials
 
     sts = boto3.client("sts")
@@ -194,11 +226,13 @@ def get_credentials(force_refresh=False) -> dict[str, str]:
         RoleArn=os.environ["SamsaraFunctionExecRoleArn"],
         RoleSessionName=os.environ["SamsaraFunctionName"],
     )
+    credentials = res["Credentials"]
     _credentials = {
-        "aws_access_key_id": res["Credentials"]["AccessKeyId"],
-        "aws_secret_access_key": res["Credentials"]["SecretAccessKey"],
-        "aws_session_token": res["Credentials"]["SessionToken"],
+        "aws_access_key_id": credentials["AccessKeyId"],
+        "aws_secret_access_key": credentials["SecretAccessKey"],
+        "aws_session_token": credentials["SessionToken"],
     }
+    _credentials_expiration = _normalize_expiration(credentials["Expiration"])
     return _credentials
 
 
@@ -210,7 +244,7 @@ def get_storage() -> Storage:
     if _storage is not None:
         return _storage
 
-    _storage = Storage(get_credentials())
+    _storage = Storage()
     return _storage
 
 

--- a/basic/just-secrets/samsarafnsecrets.py
+++ b/basic/just-secrets/samsarafnsecrets.py
@@ -1,15 +1,37 @@
-import os
-import boto3
+import datetime
 import json
+import os
 from typing import Callable
 
+import boto3
 
 _credentials: None | dict[str, str] = None
+_credentials_expiration: datetime.datetime | None = None
+_CREDENTIAL_REFRESH_MARGIN = datetime.timedelta(minutes=20)
 
 
-def get_credentials(force_refresh=False) -> dict[str, str]:
-    global _credentials
-    if _credentials is not None and not force_refresh:
+def _normalize_expiration(
+    value: str | datetime.datetime,
+) -> datetime.datetime:
+    """Return an expiration timestamp as a timezone-aware UTC datetime."""
+    if isinstance(value, str):
+        value = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=datetime.timezone.utc)
+    return value.astimezone(datetime.timezone.utc)
+
+
+def get_credentials(force_refresh: bool = False) -> dict[str, str]:
+    global _credentials, _credentials_expiration
+    refresh_deadline = (
+        datetime.datetime.now(datetime.timezone.utc) + _CREDENTIAL_REFRESH_MARGIN
+    )
+    cache_is_valid = (
+        _credentials is not None
+        and _credentials_expiration is not None
+        and refresh_deadline < _credentials_expiration
+    )
+    if cache_is_valid and not force_refresh:
         return _credentials
 
     sts = boto3.client("sts")
@@ -17,11 +39,13 @@ def get_credentials(force_refresh=False) -> dict[str, str]:
         RoleArn=os.environ["SamsaraFunctionExecRoleArn"],
         RoleSessionName=os.environ["SamsaraFunctionName"],
     )
+    credentials = res["Credentials"]
     _credentials = {
-        "aws_access_key_id": res["Credentials"]["AccessKeyId"],
-        "aws_secret_access_key": res["Credentials"]["SecretAccessKey"],
-        "aws_session_token": res["Credentials"]["SessionToken"],
+        "aws_access_key_id": credentials["AccessKeyId"],
+        "aws_secret_access_key": credentials["SecretAccessKey"],
+        "aws_session_token": credentials["SessionToken"],
     }
+    _credentials_expiration = _normalize_expiration(credentials["Expiration"])
     return _credentials
 
 

--- a/basic/persistent-storage/samsarafnstorage.py
+++ b/basic/persistent-storage/samsarafnstorage.py
@@ -1,6 +1,8 @@
 import base64
+import datetime
 import json
 import os
+
 import boto3
 import botocore.exceptions
 
@@ -11,9 +13,18 @@ class Storage:
     Can be used to store files, images, etc.
     """
 
-    def __init__(self, credentials: dict[str, str]):
+    def __init__(self):
+        credentials = get_credentials()
+        self._credentials = credentials
         self.client = boto3.client("s3", **credentials)
         self.bucket = os.environ["SamsaraFunctionStorageName"]
+
+    def _get_client(self):
+        credentials = get_credentials()
+        if credentials != self._credentials:
+            self._credentials = credentials
+            self.client = boto3.client("s3", **credentials)
+        return self.client
 
     def put(self, Key: str, Body: bytes, **kwargs):
         """
@@ -21,7 +32,7 @@ class Storage:
         Kwargs are passed to the underlying boto3.client('s3').put_object().
         Returns the original boto3 response.
         """
-        return self.client.put_object(
+        return self._get_client().put_object(
             Bucket=self.bucket,
             Key=Key,
             Body=Body,
@@ -43,7 +54,7 @@ class Storage:
         Kwargs are passed to the underlying `boto3.client('s3').get_object()`.
         Returns the original boto3 response.
         """
-        return self.client.get_object(
+        return self._get_client().get_object(
             Bucket=self.bucket,
             Key=Key,
             **kwargs,
@@ -72,7 +83,7 @@ class Storage:
         Kwargs are passed to the underlying `boto3.client('s3').delete_object()`.
         Returns the original boto3 response.
         """
-        return self.client.delete_object(
+        return self._get_client().delete_object(
             Bucket=self.bucket,
             Key=Key,
             **kwargs,
@@ -88,7 +99,7 @@ class Storage:
         Kwargs are passed to the underlying `boto3.client('s3').list_objects_v2()`.
         Returns the original boto3 response.
         """
-        return self.client.list_objects_v2(
+        return self._get_client().list_objects_v2(
             Bucket=self.bucket,
             Prefix=Prefix,
             **kwargs,
@@ -182,11 +193,32 @@ class Database:
 
 
 _credentials: None | dict[str, str] = None
+_credentials_expiration: datetime.datetime | None = None
+_CREDENTIAL_REFRESH_MARGIN = datetime.timedelta(minutes=20)
 
 
-def get_credentials(force_refresh=False) -> dict[str, str]:
-    global _credentials
-    if _credentials is not None and not force_refresh:
+def _normalize_expiration(
+    value: str | datetime.datetime,
+) -> datetime.datetime:
+    """Return an expiration timestamp as a timezone-aware UTC datetime."""
+    if isinstance(value, str):
+        value = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=datetime.timezone.utc)
+    return value.astimezone(datetime.timezone.utc)
+
+
+def get_credentials(force_refresh: bool = False) -> dict[str, str]:
+    global _credentials, _credentials_expiration
+    refresh_deadline = (
+        datetime.datetime.now(datetime.timezone.utc) + _CREDENTIAL_REFRESH_MARGIN
+    )
+    cache_is_valid = (
+        _credentials is not None
+        and _credentials_expiration is not None
+        and refresh_deadline < _credentials_expiration
+    )
+    if cache_is_valid and not force_refresh:
         return _credentials
 
     sts = boto3.client("sts")
@@ -194,11 +226,13 @@ def get_credentials(force_refresh=False) -> dict[str, str]:
         RoleArn=os.environ["SamsaraFunctionExecRoleArn"],
         RoleSessionName=os.environ["SamsaraFunctionName"],
     )
+    credentials = res["Credentials"]
     _credentials = {
-        "aws_access_key_id": res["Credentials"]["AccessKeyId"],
-        "aws_secret_access_key": res["Credentials"]["SecretAccessKey"],
-        "aws_session_token": res["Credentials"]["SessionToken"],
+        "aws_access_key_id": credentials["AccessKeyId"],
+        "aws_secret_access_key": credentials["SecretAccessKey"],
+        "aws_session_token": credentials["SessionToken"],
     }
+    _credentials_expiration = _normalize_expiration(credentials["Expiration"])
     return _credentials
 
 
@@ -210,7 +244,7 @@ def get_storage() -> Storage:
     if _storage is not None:
         return _storage
 
-    _storage = Storage(get_credentials())
+    _storage = Storage()
     return _storage
 
 


### PR DESCRIPTION
## Problem

A Lambda invocation using these helpers can fail with an AWS error such as:

```
ExpiredToken when calling ListObjectsV2: The provided token has expired
```

The failure is caused by `get_credentials()` caching temporary STS credentials in a module-level variable for the lifetime of the Lambda execution environment. The STS response includes an `Expiration` timestamp, but the helpers previously discarded it and treated any cached credential set as permanently valid.

Lambda can reuse the same warm execution environment across many invocations. The resulting sequence is:

1. A cold invocation calls `AssumeRole` and caches the returned access key, secret key, and session token.
2. The invocation finishes, but Lambda retains the imported modules and their globals.
3. The STS credentials expire.
4. A later warm invocation receives the expired cached credentials.
5. An AWS client using those static credentials fails on its next operation.

This is not specific to scheduled invocations or trigger-source handling. Scheduled workloads are simply more likely to reuse a long-lived warm environment and expose the stale cache.

## Fix

This PR updates every affected cached credential helper: four `samsarafnsecrets.py` copies and three `samsarafnstorage.py` copies.

- Cache the STS `Expiration` timestamp alongside the credential values.
- Normalize both boto3 `datetime` values and serialized ISO timestamps to timezone-aware UTC.
- Reuse credentials only when they remain valid beyond a 20-minute refresh margin.
- Call `AssumeRole` again when credentials enter that margin, while preserving the existing explicit `force_refresh` behavior.
- Before each S3 operation, check the expiration-aware credential cache.
- Reuse the existing S3 client and its HTTP connection pool while credentials remain unchanged.
- Recreate the S3 client once when refreshed credentials replace the cached values.

The 20-minute margin exceeds Lambda's 15-minute maximum invocation duration. Credentials selected at the beginning of an operation should therefore remain valid for the rest of that invocation, while also providing room for clock skew and request latency.

The secrets helpers already construct a fresh SSM client when they perform `get_parameter`; cached secret values do not perform an AWS operation. Once credential caching is expiration-aware, those SSM operations also receive current credentials.

Example workflow logic, handlers, event parameters, secrets, and scheduling configuration are unchanged.

## Scope

Updated helpers are used by:

- `basic/just-secrets`
- `basic/persistent-storage`
- `advanced/moving-legacy-scripts-to-functions`
- `advanced/painting-preview`
- `advanced/ppe-detection`

A one-time `ExpiredToken` retry is intentionally not included. Proactive expiration-aware refresh is the primary mitigation and avoids adding retry behavior to the example templates.

## Test plan

- [x] Compile all changed Python files with `python3 -m compileall`
- [x] Run focused Ruff checks for syntax and undefined names
- [x] Verify with mocked credentials that an S3 client is reused while credentials are unchanged and rebuilt after credential rotation